### PR TITLE
Phpunit 9 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - 7.2
   - 7.3
+  - 7.4
 
 before_script:
   - composer install

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ A simple Composer package which provides a TAP result printer for [PHPUnit](http
 
 ![capture](https://raw.githubusercontent.com/gh640/phpunit-tap/master/assets/capture.gif)
 
-Most of the code is blatantly copied from the official [PHPUnit TAP logger](https://github.com/sebastianbergmann/phpunit/blob/5.7/src/Util/Log/TAP.php).
-
-
 ## Usage
 
 Install the package with Composer.

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,9 @@
         }
     },
     "require": {
-        "symfony/yaml": "^4.0",
-        "phpunit/phpunit": "^8.0"
+        "php": ">=7.3",
+        "symfony/yaml": "^5.0",
+        "phpunit/phpunit": "^9.0"
     },
     "scripts": {
         "test": "phpunit tests",

--- a/src/TapResultPrinter.php
+++ b/src/TapResultPrinter.php
@@ -16,9 +16,6 @@ use Symfony\Component\Yaml\Dumper;
 
 /**
  * A TAP result printer.
- *
- * Most of the code is blatantly copied from the PHPUnit official TAP logger.
- * https://github.com/sebastianbergmann/phpunit/blob/5.7/src/Util/Log/TAP.php
  */
 class TapResultPrinter extends DefaultResultPrinter
 {

--- a/src/TapResultPrinter.php
+++ b/src/TapResultPrinter.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestFailure;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Warning;
 use PHPUnit\Runner\PhptTestCase;
-use PHPUnit\TextUI\ResultPrinter;
+use PHPUnit\TextUI\DefaultResultPrinter;
 use PHPUnit\Util\Test as TestUtil;
 use Symfony\Component\Yaml\Dumper;
 
@@ -20,7 +20,7 @@ use Symfony\Component\Yaml\Dumper;
  * Most of the code is blatantly copied from the PHPUnit official TAP logger.
  * https://github.com/sebastianbergmann/phpunit/blob/5.7/src/Util/Log/TAP.php
  */
-class TapResultPrinter extends ResultPrinter
+class TapResultPrinter extends DefaultResultPrinter
 {
 
     /**
@@ -223,7 +223,7 @@ class TapResultPrinter extends ResultPrinter
      * @param string $prefix
      * @param string $directive
      */
-    protected function writeNotOk(Test $test, $prefix = '', $directive = '')
+    protected function writeNotOk(Test $test, $prefix = '', $directive = ''): void
     {
         $this->write(
             sprintf(
@@ -240,7 +240,7 @@ class TapResultPrinter extends ResultPrinter
     /**
      * @param Test $test
      */
-    private function writeDiagnostics(Test $test)
+    private function writeDiagnostics(Test $test): void
     {
         if (!$test instanceof TestCase) {
             return;


### PR DESCRIPTION
* PHPUnit requires PHP 7.3 => dropped test in .travis.ci, added PHP 7.3 system requirement to composer.json
* The reference links to Sebastian Bergmann's original TAP printer are broken. I removed them, please feel free to add if you find a working reference link.
* `ResultPrinter` is now an interface, see https://github.com/sebastianbergmann/phpunit/issues/4024
The original Class we extend still exists, however it is marked `@internal`, so by definition we should now instead implement the Interface and reimplement a majority of the functionality in `DefaultResultPrinter`, which is also marked as `@internal`. I decided to not do that in this PR and instead continue extending the `DefaultResultPrinter`, even though it's marked as `@internal`.

Please have a look and see if anything can be improved, or if this can be merged.